### PR TITLE
Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ programming. In particular,
   can be used across libraries/languages and is thus more
   composable than using multi-prompts directly.
 
-See [`effects.c`](test/effects.c) for many examples of common 
+See [`common_effects.c`](test/common_effects.c) for many examples of common 
 effect patterns.
 
 ```C


### PR DESCRIPTION
via [ec5eff9](https://github.com/koka-lang/libmprompt/commit/ec5eff96727c8759b44223f48b1e98197506df49)

test/effects.c → test/common_effects.c