### PR TITLE
Allow tail resumptions to be discarded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(test_mpe_main_sources
     test/src/nqueens.c
     test/src/rehandle.c
     test/src/triples.c
+    test/src/sphinx.c
     test/test_mpe_main.c)    
 
 if (NOT MP_USE_C)

--- a/test/src/sphinx.c
+++ b/test/src/sphinx.c
@@ -1,0 +1,107 @@
+/* ----------------------------------------------------------------------------
+  Copyright (c) 2021, Microsoft Research, Daan Leijen
+  This is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License. A copy of the license can be
+  found in the "LICENSE" file at the root of this distribution.
+
+  The sphinx effect will only allow performers to continue execution
+  when they provide the correct answer to their riddle
+-----------------------------------------------------------------------------*/
+#include "test.h"
+#include <string.h>
+
+
+/*-----------------------------------------------------------------
+  Define operations
+-----------------------------------------------------------------*/
+MPE_DEFINE_EFFECT1(sphinx, answer)
+MPE_DEFINE_VOIDOP1(sphinx, answer, mpe_string_t)
+
+/*-----------------------------------------------------------------
+  Example programs
+-----------------------------------------------------------------*/
+
+void* brian(void* arg){
+    UNUSED(arg);
+    // Arrive at Thebes
+    sphinx_answer("Scooters");
+    // Die
+    mpt_assert(false, "Brian should have been eaten by the sphinx");
+    return mpe_voidp_int(1);
+}
+
+
+void* oedipus(void* arg){
+    UNUSED(arg);
+    // Arrive at Thebes
+    sphinx_answer("Person");
+    // Free Thebes
+    return mpe_voidp_int(1);
+}
+
+/*-----------------------------------------------------------------
+  Sphinx handler
+-----------------------------------------------------------------*/
+
+static void* _sphinx_answer(mpe_resume_t* r, void* local, void* arg){
+    if (strcmp(mpe_mpe_string_t_voidp(arg), "Person") == 0) {
+        return mpe_resume_tail(r, local, NULL);
+    } else {
+        // I couldn't find a way to release it, this one is not intended for MPE_RESUMPTION_INPLACE
+        // mpe_resume_release(r);
+        return mpe_voidp_int(0);
+    }
+}
+
+static const mpe_handlerdef_t sphinx_hdef = { MPE_EFFECT(sphinx), NULL, {
+    { MPE_OP_TAIL, MPE_OPTAG(sphinx, answer), &_sphinx_answer },
+    { MPE_OP_NULL, mpe_op_null, NULL}
+}};
+
+static void* sphinx_handle(mpe_actionfun_t action) {
+    return mpe_handle(&sphinx_hdef, NULL, action, NULL);
+}
+
+static const mpe_handlerdef_t sphinx_noop_hdef = { MPE_EFFECT(sphinx), NULL, {
+    { MPE_OP_TAIL_NOOP, MPE_OPTAG(sphinx, answer), &_sphinx_answer },
+    { MPE_OP_NULL, mpe_op_null, NULL}
+}};
+
+static void* sphinx_noop_handle(mpe_actionfun_t action) {
+    return mpe_handle(&sphinx_noop_hdef, NULL, action, NULL);
+}
+
+/*-----------------------------------------------------------------
+  testing
+-----------------------------------------------------------------*/
+
+static void oedipus_tail() {
+    int res = mpe_int_voidp(sphinx_handle(&oedipus));
+    mpt_printf("state: %d\n", res);
+    mpt_assert(res == 1, "Oedipus should pass");
+}
+
+static void oedipus_tail_noop() {
+    int res = mpe_int_voidp(sphinx_noop_handle(&oedipus));
+    mpt_printf("state: %d\n", res);
+    mpt_assert(res == 1, "Oedipus should pass");
+}
+
+static void brian_tail() {
+    int res = mpe_int_voidp(sphinx_handle(&brian));
+    mpt_printf("state: %d\n", res);
+    mpt_assert(res == 0, "Brian shouldn't pass");
+}
+
+static void brian_tail_noop() {
+    int res = mpe_int_voidp(sphinx_noop_handle(&brian));
+    mpt_printf("state: %d\n", res);
+    mpt_assert(res == 0, "Brian shouldn't pass");
+}
+
+void sphinx_run(void) {
+    oedipus_tail();
+    oedipus_tail_noop();
+    brian_tail();
+    brian_tail_noop();
+}

--- a/test/test.h
+++ b/test/test.h
@@ -37,7 +37,7 @@ void triples_run(void);
 void amb_run(void);
 void amb_state_run(void);
 void rehandle_run(void);
-
+void sphinx_run(void);
 
 #ifdef __cplusplus
 void throw_run(void);

--- a/test/test_mpe_main.c
+++ b/test/test_mpe_main.c
@@ -47,7 +47,8 @@ static void test_c(void) {
   countern_run();
   mstate_run();
   rehandle_run();
-
+  sphinx_run();
+  
   // multi-shot tests
   amb_run();
   amb_state_run();


### PR DESCRIPTION
Fixes #10 

It follows a similar approach as the one on https://github.com/koka-lang/libhandler