### PR TITLE
Fix ARM64 macOS hang: use br x30 instead of ret in mp_longjmp 

### DIFF
--- a/src/mprompt/asm/longjmp_arm64.S
+++ b/src/mprompt/asm/longjmp_arm64.S
@@ -119,7 +119,7 @@ mp_longjmp:
   ldp   d14, d15, [x0], #16
   /* always return 1 */
   mov   x0, #1
-  ret                         /* jump to lr */
+  br    x30          /* jump to lr */
 
 
 /* switch stack 


### PR DESCRIPTION
## Problem

mp_longjmp hangs on macOS ARM64 (Apple Silicon, tested on macOS 26 Tahoe). mp_prompt enters the start function but never returns — the longjmp back to the caller silently fails.

## Root Cause

On ARM64, believed ret performs return address authentication (PAC) on the link register. When mp_longjmp restores x30 (lr) from a manually saved jmpbuf, the restored value was never signed by a corresponding bl instruction. The CPU's return address prediction/authentication rejects it.

## Fix

Replace ret with br x30 in mp_longjmp. Both jump to the address in x30, but br does not perform PAC authentication on the target. 

## Testing
Tested on:

macOS 26.3 (Tahoe), Apple M-series (arm64)
Basic prompt/return, prompt/yield/resume, and the generator example all work correctly